### PR TITLE
[REVIEW] - [NA-000] - Compute optimized node

### DIFF
--- a/terraform/peer-subsystem/main.tf
+++ b/terraform/peer-subsystem/main.tf
@@ -116,7 +116,7 @@ module "eks" {
       min_size     = 2
       max_size     = 20
 
-      instance_types = ["t3.xlarge"]
+      instance_types = ["c6g.2xlarge"]
       k8s_labels = {
         workerType = "managed_ec2_node_groups"
       }


### PR DESCRIPTION
Instance Size | vCPU | Memory (GiB) | Instance Storage (GB) | Network Bandwidth (Gbps)*** 
-- | -- | -- | -- | -- | --
c6g.2xlarge | 8 | 16 | EBS-Only | Up to 10 

(Double of CPUs and network bandwidth)
(Same Memory as t3.xlarge)
